### PR TITLE
change default config file to config.local

### DIFF
--- a/formidable.py
+++ b/formidable.py
@@ -3,7 +3,7 @@ from flask_mail import Mail, Message
 from os import environ
 
 app = Flask(__name__)
-app.config.from_object('config.default')
+app.config.from_object('config.local')
 settings = environ.get('FORMIDABLE_SETTINGS_MODULE', None)
 if settings:
     app.config.from_object(settings)


### PR DESCRIPTION
This change will change the used config file in formidably.py to *config.local* instead of *config.default* to match the README.